### PR TITLE
Feature/reconhecimento

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ReconhecimentoModule } from './reconhecimentos/reconhecimento.module';
 
 @Module({
-  imports: [],
+  imports: [ReconhecimentoModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,23 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe());
+  
+  const config = new DocumentBuilder()
+    .setTitle('Reconhecimento API')
+    .setDescription('Documentação da API com Swagger')
+    .setVersion('1.0')
+    .addTag('reconhecimentos')
+    .build();
+    
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
+
 }
 bootstrap();

--- a/src/reconhecimentos/dto/create-reconhecimento.dto.ts
+++ b/src/reconhecimentos/dto/create-reconhecimento.dto.ts
@@ -1,0 +1,25 @@
+import { PickType, ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsNumber, IsString, Min } from "class-validator";
+import { Reconhecimento } from "../entities/reconhecimento";
+
+export class CreateReconhecimentoDto extends PickType(Reconhecimento, ['uuid', 'id', 'from', 'to', 'message', 'coins'] as const) {
+    
+    @ApiProperty({ example: 'Ciclano da Silva' })
+    @IsNotEmpty({ message: "O remetente é obrigatorio!"})
+    from: string;
+    
+    @ApiProperty({ example: 'Fulano da Silva' })
+    @IsNotEmpty({ message: "O destinatario é obrigatorio!"})
+    to: string;
+    
+    @ApiProperty({ example: 'Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!' })
+    @IsString({ message: 'A mensagem deve ser uma string' })
+    @IsNotEmpty({ message: "A mensagem é obrigatoria!"})
+    message: string;
+    
+    @ApiProperty({ example: 10 })
+    @IsNumber({}, { message: 'A quantidade de moedas deve ser um número' })
+    @IsNotEmpty({ message: "A quantidade de moedas é obrigatorio!"})
+    @Min(1, { message: 'O valor da moeda deve ser positivo e maior que 0' })
+    coins: number;
+}

--- a/src/reconhecimentos/entities/reconhecimento.ts
+++ b/src/reconhecimentos/entities/reconhecimento.ts
@@ -1,0 +1,9 @@
+
+export class Reconhecimento {
+    uuid: string;
+    id: number;
+    from: string;
+    to: string;
+    message: string; 
+    coins: number; 
+}

--- a/src/reconhecimentos/reconhecimento.controller.spec.ts
+++ b/src/reconhecimentos/reconhecimento.controller.spec.ts
@@ -1,0 +1,131 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReconhecimentoController } from './reconhecimento.controller';
+import { ReconhecimentoService } from './reconhecimento.service';
+import { ReconhecimentoRepository } from './reconhecimento.repository';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ReconhecimentoController', () => {
+  let controller: ReconhecimentoController;
+  let service: ReconhecimentoService;
+
+  const mockService = {
+    create: jest.fn(dto => ( { id: 1, ...dto})),
+    findAll: jest.fn(() => [
+      {
+        "uuid": "1",
+        "id": 1,
+        "from": "Beltrano",
+        "to": "Ciclano",
+        "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+        "coins": 1
+      }
+    ]),
+    findById: jest.fn(id => {
+      if(id === 1) {
+        return {
+          "uuid": "1",
+          "id": 1,
+          "from": "Beltrano",
+          "to": "Ciclano",
+          "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+          "coins": 1
+        }
+      }
+      throw new NotFoundException();
+    }),
+    remove: jest.fn(id => {
+      if(id === 1) {
+        return {
+          "uuid": "1",
+          "id": 1,
+          "from": "Beltrano",
+          "to": "Ciclano",
+          "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+          "coins": 1
+        }
+      }
+      throw new NotFoundException();
+    }),
+  };
+  
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ReconhecimentoController],
+      providers: [
+        {
+          provide: ReconhecimentoService,
+          useValue: mockService,
+        }, 
+        ReconhecimentoRepository
+        ],
+      
+    }).compile();
+
+    controller = module.get<ReconhecimentoController>(ReconhecimentoController);
+    service = module.get<ReconhecimentoService>(ReconhecimentoService);
+  });
+
+  it('deve cadastrar um reconhecimento', async () => {
+    const reconhecimento = {
+      "uuid": "1",
+      "id": 1,
+      "from": "Beltrano",
+      "to": "Ciclano",
+      "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      "coins": 1
+    };
+
+    const resultado = await controller.create(reconhecimento);
+
+    expect(resultado).toEqual({
+      "uuid": "1",
+      "id": 1,
+      "from": "Beltrano",
+      "to": "Ciclano",
+      "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      "coins": 1
+    });
+    expect(service.create).toHaveBeenCalledWith(reconhecimento);
+  });
+
+  it('deve retornar todos os reconhecimentos', () => {
+    const resultado = controller.findAll();
+    expect(resultado).toEqual([
+      {
+        "uuid": "1",
+        "id": 1,
+        "from": "Beltrano",
+        "to": "Ciclano",
+        "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+        "coins": 1
+      },
+    ]);
+    expect(service.findAll).toHaveBeenCalled();
+  });
+
+  it('deve retornar um reconhecimento por ID', () => {
+    const result = controller.findById(1);
+    expect(result).toEqual({
+      "uuid": "1",
+      "id": 1,
+      "from": "Beltrano",
+      "to": "Ciclano",
+      "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      "coins": 1
+    });
+    expect(service.findById).toHaveBeenCalledWith(1);
+  });
+
+  it('deve remover um reconhecimento por ID', () => {
+    const result = controller.remove(1);
+    expect(result).toEqual({
+      "uuid": "1",
+      "id": 1,
+      "from": "Beltrano",
+      "to": "Ciclano",
+      "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      "coins": 1
+    });
+    expect(service.remove).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/reconhecimentos/reconhecimento.controller.ts
+++ b/src/reconhecimentos/reconhecimento.controller.ts
@@ -1,0 +1,50 @@
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import { ReconhecimentoService } from './reconhecimento.service';
+import { CreateReconhecimentoDto } from './dto/create-reconhecimento.dto';
+import { ApiBody, ApiTags, ApiResponse, ApiParam } from '@nestjs/swagger';
+
+@ApiTags('recognitions')
+@Controller('recognitions')
+export class ReconhecimentoController {
+    constructor(private readonly reconhecimentoService: ReconhecimentoService) {}
+
+    @ApiBody({type: CreateReconhecimentoDto })
+    @ApiResponse({ status: 201, description: 'Reconhecimento criado com sucesso' })
+    @ApiResponse({ status: 400, description: 'Dados inválidos' })
+    @Post()
+    create(@Body() reconhecimentoDto: CreateReconhecimentoDto) {
+        return this.reconhecimentoService.create(reconhecimentoDto);
+    }
+
+    @ApiResponse({
+        status: 200,
+        description: 'Lista de todas os reconhecimentos',
+        type: CreateReconhecimentoDto,
+        isArray: true,
+    })
+    @ApiResponse({ status: 400, description: 'Dados não encontrados!' })
+    @Get()
+    findAll() {
+        return this.reconhecimentoService.findAll();
+    }
+    
+    @ApiParam({ name: 'id', type: Number, description: 'Id do reconhecimento' })
+    @ApiResponse({
+        status: 200,
+        description: 'Reconhecimento encontrado com sucesso!',
+        type: CreateReconhecimentoDto,
+    })
+    @ApiResponse({ status: 404, description: 'Reconhecimento não encontrado!' })
+    @Get(':id')
+    findById(@Param('id') id: number) {
+        return this.reconhecimentoService.findById(+id);
+    }
+
+    @ApiParam({ name: 'id', type: Number, description: 'Id do reconhecimento' })
+    @ApiResponse({ status: 200, description: 'Reconhecimento removido com sucesso' })
+    @ApiResponse({ status: 404, description: 'Reconhecimento não encontrado' })
+    @Delete(':id')
+    remove(@Param('id') id: number) {
+        return this.reconhecimentoService.remove(+id);
+    }
+}

--- a/src/reconhecimentos/reconhecimento.module.ts
+++ b/src/reconhecimentos/reconhecimento.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ReconhecimentoController } from './reconhecimento.controller';
+import { ReconhecimentoService } from './reconhecimento.service';
+import { ReconhecimentoRepository } from './reconhecimento.repository';
+
+@Module({
+  controllers: [ReconhecimentoController],
+  providers: [ReconhecimentoService, ReconhecimentoRepository]
+})
+export class ReconhecimentoModule {}

--- a/src/reconhecimentos/reconhecimento.repository.ts
+++ b/src/reconhecimentos/reconhecimento.repository.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+import { Reconhecimento } from "./entities/reconhecimento";
+import { CreateReconhecimentoDto } from "./dto/create-reconhecimento.dto";
+
+@Injectable()
+export class ReconhecimentoRepository {
+    reconhecimentos: Reconhecimento[] = 
+    [
+        {
+            uuid: "1",
+            id: 1,
+            from: "Fulano",
+            to: "Ciclano",
+            message: "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+            coins: 10
+        },
+        {
+            uuid: "2",
+            id: 2,
+            from: "Ciclano",
+            to: "Fulano",
+            message: "Obrigado por sempre colaborar com o time, sua energia contagia a todos!",
+            coins: 10
+        }
+    ];
+
+    save(reconhecimento: CreateReconhecimentoDto) {
+        this.reconhecimentos.push(reconhecimento);
+        return reconhecimento;
+    }
+
+    find() {
+        return this.reconhecimentos;
+    }
+
+    findById(id: number) {
+        return this.reconhecimentos.find((reconhecimento: CreateReconhecimentoDto) => reconhecimento.id === id);
+    }
+
+    delete(id: number) {
+        this.reconhecimentos = this.reconhecimentos.filter((reconhecimento) => reconhecimento.id !== id);
+    }
+}

--- a/src/reconhecimentos/reconhecimento.service.spec.ts
+++ b/src/reconhecimentos/reconhecimento.service.spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ReconhecimentoService } from './reconhecimento.service';
+import { ReconhecimentoRepository } from './reconhecimento.repository';
+
+describe('ReconhecimentoService', () => {
+  let service: ReconhecimentoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ReconhecimentoService, ReconhecimentoRepository],
+    }).compile();
+
+    service = module.get<ReconhecimentoService>(ReconhecimentoService);
+  });
+
+  it('deve cadastrar um reconhecimento', async () => {
+
+    const reconhecimento = {
+      "uuid": "3",
+      "id": 3,
+      "from": "Beltrano",
+      "to": "Ciclano",
+      "message": "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      "coins": 1
+    };
+
+    const resultado = await service.create(reconhecimento);
+
+    expect(resultado).toHaveProperty('id');
+    expect(resultado).toHaveProperty('uuid');
+    expect(resultado.from).toBe('Beltrano');
+    expect(resultado.to).toBe('Ciclano');
+    expect(resultado.message).toBe('Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!');
+    expect(resultado.coins).toBe(1);
+  });
+
+  it('deve retornar um array com todos os reconhecimentos', async () => {
+
+    const resultado = await service.findAll();
+
+    expect(Array.isArray(resultado)).toBe(true);
+    expect(resultado.length).toBeGreaterThan(0);
+
+    resultado.forEach((reconhecimento) => {
+      expect(reconhecimento).toHaveProperty('id');
+      expect(reconhecimento).toHaveProperty('uuid');
+      expect(reconhecimento).toHaveProperty('from');
+      expect(reconhecimento).toHaveProperty('to');
+      expect(reconhecimento).toHaveProperty('message');
+      expect(reconhecimento).toHaveProperty('coins');
+    });
+  });
+
+  it('deve retornar um reconhecimento com o ID fornecido', async () => {
+    const resultado = await service.findById(1);
+
+    expect(resultado).toEqual({
+      uuid: "1",
+      id: 1,
+      from: "Fulano",
+      to: "Ciclano",
+      message: "Excelente trabalho na entrega do projeto, sua dedicação fez toda a diferença!",
+      coins: 10
+    });
+  });
+
+  it('deve excluir um reconhecimento com o ID fornecido', async () => {
+    await service.remove(1);
+
+    const removido = await service.findById(1);
+
+    expect(removido).toBeUndefined();
+
+  });
+});

--- a/src/reconhecimentos/reconhecimento.service.ts
+++ b/src/reconhecimentos/reconhecimento.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { ReconhecimentoRepository } from './reconhecimento.repository';
+import { CreateReconhecimentoDto } from './dto/create-reconhecimento.dto';
+
+@Injectable()
+export class ReconhecimentoService {
+    constructor(private readonly repositorio: ReconhecimentoRepository) {}
+
+    async create(reconhecimento: CreateReconhecimentoDto): Promise<CreateReconhecimentoDto> {
+        return await this.repositorio.save(reconhecimento);
+    }
+    
+    async findAll() {
+        return await this.repositorio.find();
+    }
+
+    async findById(id: number) {
+        return await this.repositorio.findById(id);
+    }
+
+    async remove(id: number) {
+        await this.repositorio.delete(id);
+        return `O reconhecimento ${id} foi removido com sucesso`;
+    }
+}


### PR DESCRIPTION
## 📌 O que foi feito

- Criação do endpoint de reconhecimento de colaboradores
- Adição dos métodos `create, findAll, findById, remove` no service e no repository
- Testes unitários para garantir funcionamento

## 🧠 Por que foi feito

Parte da feature de gamificação: usuários podem reconhecer colegas e distribuir coins.

## 🧪 Como testar

- `POST /recognitions` com body válido deve retornar 201 e o objeto criado
- `GET/recognitions` lista todos os reconhecimentos 200 um array de objetos é retornado
- GET/recognitions/:id` deve retornar o reconhecimento por ID 200 um objeto é retornado
- DEL/recognitions/:id` deve deletar o reconhecimento por ID 200 um objeto é removido do mock
- Executar `npm run test` — todos devem passar

## ⚠️ Observações

- O UUID está sendo mockado por enquanto
- Ainda sem integração com banco real (usando array local)